### PR TITLE
HOME-46 - Display full names of agents instead od ID's

### DIFF
--- a/controllers/utils/render.go
+++ b/controllers/utils/render.go
@@ -19,9 +19,9 @@ func RenderTemplate(w http.ResponseWriter, r *http.Request, name string, sm ISes
 		log.Fatal(err)
 	}
 
-    menu := make([]string, 0)
+    menu := make([]services.Agent, 0)
     for _, a := range services.Agents {
-        menu = append(menu, a.Name)
+        menu = append(menu, a)
     }
 
     params := make(map[string]interface{})

--- a/hardware/agents.config
+++ b/hardware/agents.config
@@ -1,1 +1,1 @@
-livingroom AGENTDEV1 192.168.1.9
+livingroom:Living room:192.168.1.9

--- a/services/home.go
+++ b/services/home.go
@@ -19,6 +19,7 @@ const (
 )
 
 type Agent struct {
+    Id          string
     Name        string
     Url         string
 }
@@ -64,10 +65,11 @@ func writePackage(port *serial.Port) {
     }
 }
 
-func addAgent(name string, device string, url string) {
+func addAgent(id string, name string, url string) {
     log.Println("services: adding home agent '" + name + "'")
 
     agent := Agent{
+        Id: id,
         Name: name,
         Url: url,
     }
@@ -151,15 +153,15 @@ func setupAgents() {
     agentsConf := strings.Split(string(agentsCnf), "\n")
 
     for _, c := range agentsConf {
-        agentConf := strings.Split(c, " ")
+        agentConf := strings.Split(c, ":")
 
         if (len(agentConf) == 3) {
             id := agentConf[0]
-            device := agentConf[1]
+            name := agentConf[1]
             ip := agentConf[2]
             apiUrl := "http://" + ip + "/api"
 
-            addAgent(id, device, apiUrl)
+            addAgent(id, name, apiUrl)
         }
     }
 }

--- a/views/dashboard.html
+++ b/views/dashboard.html
@@ -8,8 +8,8 @@
             <ul class="c-list">
                 {{ range index .Params "menu"}}
                 <li class="c-list__item">
-                    <a href="/agent/{{.}}">
-                        {{.}}
+                    <a href="/agent/{{.Id}}">
+                        {{.Name}}
                     </a>
                 </li>
                 {{ end }}


### PR DESCRIPTION
**Business justification:** https://trello.com/c/GymUUS0F/46-home-46-display-full-names-of-agents-instead-of-ids

**Description:** For now IDs were displayed instead of more pleasant for humans names. This PR aims to change this.

Visual overview:
![home-46-pr](https://user-images.githubusercontent.com/3702926/46163600-e26f7c80-c28b-11e8-9ad6-363c2a63806f.png)
