### PR TITLE
HOME-59 - Implement fallback when agent is not on-line

### DIFF
--- a/services/home.go
+++ b/services/home.go
@@ -81,6 +81,12 @@ func addAgent(id string, name string, url string) {
 
 func (a Agent) fetchPackage() {
     response, err := http.Get(a.URL)
+
+    if err != nil {
+        log.Println("services:  agent '" + a.Name + "'", err)
+        return
+    }
+
     defer response.Body.Close()
 
     contents, err := ioutil.ReadAll(response.Body)

--- a/views/dashboard.html
+++ b/views/dashboard.html
@@ -8,7 +8,7 @@
             <ul class="c-list">
                 {{ range index .Params "menu"}}
                 <li class="c-list__item">
-                    <a href="/agent/{{.Id}}">
+                    <a href="/agent/{{.ID}}">
                         {{.Name}}
                     </a>
                 </li>


### PR DESCRIPTION
**Business justification:** https://trello.com/c/D7OGzZtc/59-home-59-implement-fallback-when-agent-is-not-on-line

**Description:**  Implement fallback when agent is off-line. Log the error and don't perform any specific actions - just prefent panicing.

This PR includes also a minor template fix related with lastest refactoring.