### PR TITLE
HOME-66 - User should be allowed to register only from intra-net

### DIFF
--- a/controllers/utils/intranet.go
+++ b/controllers/utils/intranet.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+    "net"
+    "net/http"
+    "strings"
+)
+
+func IsRequestFromIntranet(r *http.Request) bool {
+    isPrivate := false
+    decomposedAddr := strings.Split(r.RemoteAddr, ":")
+    pureIP := decomposedAddr[0]
+    IP := net.ParseIP(pureIP)
+
+    _, private24BitBlock, _ := net.ParseCIDR("10.0.0.0/8")
+    _, private20BitBlock, _ := net.ParseCIDR("172.16.0.0/12")
+    _, private16BitBlock, _ := net.ParseCIDR("192.168.0.0/16")
+
+    isPrivate = private24BitBlock.Contains(IP) || private20BitBlock.Contains(IP) || private16BitBlock.Contains(IP)
+
+    return isPrivate
+}
+

--- a/controllers/utils/render.go
+++ b/controllers/utils/render.go
@@ -12,10 +12,12 @@ import (
 	"github.com/oskarszura/gowebserver/session"
 )
 
+
 // RenderTemplate - helper for page rendering
 func RenderTemplate(w http.ResponseWriter, r *http.Request, name string, sm session.ISessionManager) {
     sessionID, _ := utils.GetSessionID(r)
     isLogged := sm.IsExist(sessionID)
+    isPrivate := IsRequestFromIntranet(r)
 
     if !isLogged {
         utils.ClearSession(w)
@@ -25,11 +27,15 @@ func RenderTemplate(w http.ResponseWriter, r *http.Request, name string, sm sess
         }
     }
 
-	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+    if !isPrivate && r.URL.Path == "/login/register" {
+        http.Redirect(w, r, "/login", http.StatusSeeOther)
+    }
 
-	if err != nil {
-		log.Fatal(err)
-	}
+    dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+
+    if err != nil {
+        log.Fatal(err)
+    }
 
     menu := make([]services.Agent, 0)
     for _, a := range services.Agents {

--- a/controllers/utils/render.go
+++ b/controllers/utils/render.go
@@ -45,7 +45,7 @@ func RenderTemplate(w http.ResponseWriter, r *http.Request, name string, sm sess
     params := make(map[string]interface{})
     params["menu"] = menu
 
-    templateModel := models.Page{utils.VERSION, name, true, params}
+    templateModel := models.Page{utils.VERSION, name, isLogged, params}
 
 	template := template.Must(
         template.ParseFiles(

--- a/services/home.go
+++ b/services/home.go
@@ -9,7 +9,6 @@ import (
     "errors"
     "strings"
     "strconv"
-    "github.com/tarm/serial"
     "github.com/influxdata/influxdb/client/v2"
     "github.com/oskarszura/smarthome/utils"
 )
@@ -68,13 +67,6 @@ func getGas(data string) string {
 
 func getSound(data string) string {
     return strings.Split(data, "|")[3]
-}
-
-func writePackage(port *serial.Port) {
-    _, err := port.Write([]byte("CMD001"))
-    if err != nil {
-        log.Println("services: ", err)
-    }
 }
 
 func addAgent(id string, name string, url string) {

--- a/views/navigation.html
+++ b/views/navigation.html
@@ -10,6 +10,22 @@
                     Dashboard
                 </a>
             </li>
+            {{if not .IsLogged}}
+            <li class="c-navigation__option"
+                role="presentation">
+                <a class="c-navigation__link" href="/login">
+                    Login
+                </a>
+            </li>
+            {{end}}
+            {{if .IsLogged}}
+            <li class="c-navigation__option"
+                role="presentation">
+                <a class="c-navigation__link" href="/login/logout">
+                    Logout
+                </a>
+            </li>
+            {{end}}
         </ul>
     </nav>
 </header>


### PR DESCRIPTION
**Business justification:** https://trello.com/c/SM3dFyUb/66-home-66-user-should-be-allowed-to-register-only-from-intra-net

**Description:** When requesting client IP is recognised as from internet rather than from intranet (based on CIDR), redirect to login page. Registering users should be available only from the intranet.
