### PR TITLE
HOME-69 - Send email alerts to all registered users

### DIFF
--- a/services/email.go
+++ b/services/email.go
@@ -29,11 +29,11 @@ func SendEmail(body string, recipient string) {
     err := smtp.SendMail(smtpPort, smtpAuth, sender, []string{recipient}, []byte(msg))
 
     if err != nil {
-        log.Println("services: ", err)
+        log.Println("services: error sending email to " + recipient, err)
         return
     }
 
-    log.Println("services: alert sent")
+    log.Println("services: alert sent to " + recipient)
 }
 
 // BulkEmail - sends alerts to all home users
@@ -46,7 +46,7 @@ func BulkEmail(body string) {
     err := c.Find(bson.M{}).All(&users)
 
     if err != nil {
-        log.Println("services: Alert recipients not found err=", err)
+        log.Println("services: Alert recipients not found", err)
     }
 
     for _, u := range users {

--- a/services/home.go
+++ b/services/home.go
@@ -112,12 +112,12 @@ func (a Agent) fetchPackage() {
 
     if utils.IsAlerts == true {
         if t, err := strconv.ParseFloat(temperature, 32); err == nil {
-            if t > 30 {
+            if t > 40 {
                 now := time.Now()
 
                 if now.Sub(tmpNotifyTime).Hours() >= 1 {
                     tmpNotifyTime = now
-                    SendEmail("[" + now.UTC().String() + "] temperature = " + temperature)
+                    BulkEmail("[" + now.UTC().String() + "][" + a.Name + "] temperature = " + temperature)
                 }
             }
         }
@@ -127,7 +127,7 @@ func (a Agent) fetchPackage() {
 
             if now.Sub(motionNotifyTime).Hours() >= 1 {
                 motionNotifyTime = now
-                SendEmail("[" + now.UTC().String() + "] motion detected")
+                BulkEmail("[" + now.UTC().String() + "][" + a.Name + "] motion detected")
             }
         }
 
@@ -136,7 +136,7 @@ func (a Agent) fetchPackage() {
 
             if now.Sub(gasNotifyTime).Hours() >= 1 {
                 gasNotifyTime = now
-                SendEmail("[" + now.UTC().String() + "] gas alert")
+                BulkEmail("[" + now.UTC().String() + "][" + a.Name + "] gas detected")
             }
         }
     }


### PR DESCRIPTION
**Business justification:** https://trello.com/c/5gnuGYXn/69-send-email-alerts-to-all-registered-users

**Description:** Instead of sending email to one hardcoded recipient in ENV variables, send alerts to all system users.
