### PR TITLE
HOME-93 - Rewrite fetching package to be concurrent

### DIFF
--- a/models/agent/agent.go
+++ b/models/agent/agent.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+    "sync"
     "log"
     "io/ioutil"
     "net/http"
@@ -114,14 +115,19 @@ func getSound(data string) string {
 }
 
 // FetchPackage - fetches data packages
-func (a *Agent) FetchPackage(alertNotifier func(string), persistData func(*Agent, map[string]interface{}), isAlerts bool) {
+func (a *Agent) FetchPackage(
+    alertNotifier func(string),
+    persistData func(*Agent, map[string]interface{}),
+    isAlerts bool,
+    wg *sync.WaitGroup,
+){
+    defer wg.Done()
     response, err := http.Get(a.uRL)
 
     if err != nil {
         log.Println("agent/FetchPackage: agent '" + a.name + "'", err)
         return
     }
-
     defer response.Body.Close()
 
     contents, err := ioutil.ReadAll(response.Body)

--- a/processes/homebot/homebot.go
+++ b/processes/homebot/homebot.go
@@ -52,6 +52,7 @@ func (hb *HomeBot) runCommunicationLoop() {
         }
 
         agents := hb.state.Agents()
+        done := make(chan bool)
         var wg sync.WaitGroup
         wg.Add(len(agents))
 
@@ -64,7 +65,17 @@ func (hb *HomeBot) runCommunicationLoop() {
             }
         }
 
-        wg.Wait()
+        go func() {
+            wg.Wait()
+            close(done)
+        }()
+
+        switch {
+        case <- done:
+            continue
+        case <-time.After(3 * time.Second):
+            continue
+        }
     }
 }
 

--- a/processes/homebot/homebot.go
+++ b/processes/homebot/homebot.go
@@ -70,7 +70,7 @@ func (hb *HomeBot) runCommunicationLoop() {
             close(done)
         }()
 
-        switch {
+        select {
         case <-done:
             continue
         case <-time.After(3 * time.Second):

--- a/processes/homebot/homebot.go
+++ b/processes/homebot/homebot.go
@@ -52,7 +52,7 @@ func (hb *HomeBot) runCommunicationLoop() {
         }
 
         agents := hb.state.Agents()
-        done := make(chan bool)
+        done := make(chan struct{})
         var wg sync.WaitGroup
         wg.Add(len(agents))
 
@@ -71,7 +71,7 @@ func (hb *HomeBot) runCommunicationLoop() {
         }()
 
         switch {
-        case <- done:
+        case <-done:
             continue
         case <-time.After(3 * time.Second):
             continue

--- a/processes/homebot/homebot.go
+++ b/processes/homebot/homebot.go
@@ -3,6 +3,7 @@ package homebot
 import (
     "log"
     "time"
+    "sync"
     "github.com/influxdata/influxdb/client/v2"
     "github.com/smart-evolution/smarthome/models/agent"
     "github.com/smart-evolution/smarthome/datasources/dataflux"
@@ -51,15 +52,19 @@ func (hb *HomeBot) runCommunicationLoop() {
         }
 
         agents := hb.state.Agents()
+        var wg sync.WaitGroup
+        wg.Add(len(agents))
 
         for i := 0; i < len(agents); i++ {
             a := agents[i]
             log.Println("homebot/runCommunicationLoop: fetching from=", a.Name())
 
             if a.AgentType() == "type1" {
-                a.FetchPackage(hb.mailer.BulkEmail, persistData(hb.store), hb.state.IsAlerts())
+                go a.FetchPackage(hb.mailer.BulkEmail, persistData(hb.store), hb.state.IsAlerts(), &wg)
             }
         }
+
+        wg.Wait()
     }
 }
 


### PR DESCRIPTION
**Business justification:** https://trello.com/c/iaqZGQoP/93-home-93-rewrite-fetching-package-to-be-concurrent

**Description:** Implement package fetching to be asynchronous (using waiting groups and channels). This way homebot will perform fetching more efficiently.
