### PR TITLE
HOME-96 - Integrate newer sh-versioner

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 REPOSITORY=http://github.com/oskarszura/smarthome
-NEWER_TAG=$(git tag | tail -r | sed -n 1p)
-OLDER_TAG=$(git tag | tail -r | sed -n 2p)
+NEWER_TAG=$(git tag --sort version:refname | tail -r | sed -n 1p)
+OLDER_TAG=$(git tag --sort version:refname | tail -r | sed -n 2p)
 HEADER="# Changelog from $NEWER_TAG"
 DIR=./docs/changelogs
 


### PR DESCRIPTION
**Business justification:** https://trello.com/c/IyNgHnpf/96-home-96-integrate-newer-sh-versioner

**Description:** Versions above v0.9.0 (containing two digits) were causing changelog problems. This PR adopts newer sh-versioner and fixes the issue.

