### PR TITLE
HOME-90 - Fix routing to particular agent

### DIFF
--- a/processes/webserver/webserver.go
+++ b/processes/webserver/webserver.go
@@ -39,6 +39,7 @@ func New(port string, store dataflux.IDataFlux, persistence persistence.IPersist
 
     server := gowebserver.New(serverOptions, controllers.NotFound)
 
+    server.Router.AddRoute("/agent/{agent}", controllers.CtrDashboard)
     server.Router.AddRoute("/login/register", controllers.Register)
     server.Router.AddRoute("/login/logout", controllers.AuthenticateLogout)
     server.Router.AddRoute("/login", controllers.Authenticate)


### PR DESCRIPTION
**Business justification:** https://trello.com/c/TZaRVMa4/90-home-90-fix-routing-to-particular-agent

**Description:** Previous installing of ReactRouter caused removal of backend routing which caused 404 when redirecting to a particular agent. This PR fixes the issue by retrieving the same routing back.
