### PR TITLE
HOME-127 - Add to cli-server 'proxy' option

### DIFF
--- a/processes/cliserver/cliserver.go
+++ b/processes/cliserver/cliserver.go
@@ -2,8 +2,10 @@ package cliserver
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/smart-evolution/smarthome/utils"
 	"net"
+	"os"
 )
 
 func handleRequest(conn net.Conn) {
@@ -17,15 +19,54 @@ func handleRequest(conn net.Conn) {
 		return
 	}
 
-	msg := make(map[string]interface{})
+	msg := make(map[string]string)
 	json.Unmarshal(buff[:n], &msg)
 
 	cmd := msg["cmd"]
+	param := msg["param"]
+
+	fmt.Println(msg)
 
 	if cmd == "status" {
 		conn.Write([]byte("application up and running"))
+	} else if cmd == "proxy" {
+		devAddr := param
+		devConn, err := net.Dial("tcp", devAddr)
+
+		if err != nil {
+			fmt.Println("error connecting to device" + devAddr)
+			os.Exit(1)
+		}
+		_, err = devConn.Write([]byte("CMDWHO"))
+
+		resBuff := make([]byte, 512)
+		devResBuff := make([]byte, 512)
+		n, err := devConn.Read(devResBuff)
+
+		if err != nil {
+			fmt.Println("error retrieving device type")
+			os.Exit(1)
+		}
+
+		_, err = conn.Write(devResBuff[:n])
+
+		for {
+			n, _ := conn.Read(resBuff)
+			devConn.Write(resBuff[:n])
+
+			if string(resBuff[:n]) == "CMDLOK" {
+				n, err := devConn.Read(devResBuff)
+
+				if err != nil {
+					fmt.Println("RES: error reading message from device")
+					break
+				}
+
+				conn.Write(devResBuff[:n])
+			}
+		}
 	} else {
-		utils.Log("invalid cli command")
+		utils.Log("invalid cli command '" + cmd + "'")
 	}
 
 	conn.Close()

--- a/processes/cliserver/cliserver.go
+++ b/processes/cliserver/cliserver.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/smart-evolution/smarthome/utils"
 	"net"
-	"os"
 )
 
 func handleRequest(conn net.Conn) {
@@ -34,8 +33,8 @@ func handleRequest(conn net.Conn) {
 		devConn, err := net.Dial("tcp", devAddr)
 
 		if err != nil {
-			fmt.Println("error connecting to device" + devAddr)
-			os.Exit(1)
+			fmt.Println("error connecting to device " + devAddr)
+			return
 		}
 		_, err = devConn.Write([]byte("CMDWHO"))
 
@@ -45,7 +44,7 @@ func handleRequest(conn net.Conn) {
 
 		if err != nil {
 			fmt.Println("error retrieving device type")
-			os.Exit(1)
+			return
 		}
 
 		_, err = conn.Write(devResBuff[:n])


### PR DESCRIPTION
**Business justification:** HOME-127 - Add to cli-server 'proxy' option

**Description:** Sometimes users might want to connect to their home devices from outside of the internal network. Smarthome CLI server should handle `proxy` command to take control over those devices.

**Related PRs:**
* https://github.com/smart-evolution/smarthome-cli/pull/9
