### PR TITLE
HOME-134 - Closing connections to clients doesn't work

### DIFF
--- a/processes/cliserver/cliserver.go
+++ b/processes/cliserver/cliserver.go
@@ -62,6 +62,8 @@ func handleRequest(conn net.Conn) {
 				}
 
 				conn.Write(devResBuff[:n])
+			} else if string(resBuff[:n]) == "CMDDIS" {
+				conn.Close()
 			}
 		}
 	} else {


### PR DESCRIPTION
**Business justification:** HOME-134 - Closing connections to clients doesn't work

**Description:** When user was connected to the device via smarthome-cli and killed the connection from the CLI point of view, hardware was still 'thinking' it was connected. This PR creates a command that can be sent to container in channel 0 to close the connection.

**Related PRs:**
* https://github.com/smart-evolution/smart-home-uc/pull/5
* https://github.com/smart-evolution/smarthome-cli/pull/10
* https://github.com/smart-evolution/smarthome/pull/61
* https://github.com/smart-evolution/smart-home-agent-esp8266/pull/5