### PR TITLE
HOME-149 - Remove Elm as it's not available for RPI yet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ mode=prod
 .PHONY: install
 install:
 	$(NPM) install
-	$(NPM) run elm:package:install --yes
 	$(GOCMD) get github.com/coda-it/gowebserver
 	$(GOCMD) get github.com/influxdata/influxdb1-client/v2
 	$(GOCMD) get gopkg.in/mgo.v2

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Smarthome",
   "main": "index.js",
   "scripts": {
-    "elm:package:install": "elm package install --yes",
     "build:dev": "webpack --mode=development --config webpack.dev.config.js",
     "build:prod": "webpack --mode=production --config webpack.prod.config.js",
     "lint": "eslint --ext .js,.jsx .",
@@ -51,8 +50,6 @@
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.4",
     "css-loader": "^0.25.0",
-    "elm": "^0.18.0",
-    "elm-webpack-loader": "^4.2.0",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.9.1",
     "enzyme-to-json": "^3.3.5",


### PR DESCRIPTION
**Business justification:** https://trello.com/c/uNMfDCI2/149-home-149-remove-elm-as-its-not-available-for-rpi-yet

**Description:** `elm install` blocks `make install` on RPI docker as it's not available yet on this build. It's not used either way so it can be removed.
