### PR TITLE
HOME-188 - Fix agent dups while sniffing

### DIFF
--- a/datasources/state/state.go
+++ b/datasources/state/state.go
@@ -15,6 +15,7 @@ type IState interface {
 	AddAgent(string, string, string, string)
 	Agents() []agent.IAgent
 	AgentByID(string) (agent.IAgent, error)
+	AgentByIP(string) (agent.IAgent, error)
 }
 
 // State - data source which keeps short data in memory
@@ -69,6 +70,17 @@ func (s *State) Agents() []agent.IAgent {
 func (s *State) AgentByID(id string) (agent.IAgent, error) {
 	for _, a := range s.agents {
 		if a.ID() == id {
+			return a, nil
+		}
+	}
+
+	return &agent.Agent{}, errors.New("No matching agent")
+}
+
+// AgentByIP - find corresponding agent by ID
+func (s *State) AgentByIP(ip string) (agent.IAgent, error) {
+	for _, a := range s.agents {
+		if a.IP() == ip {
 			return a, nil
 		}
 	}

--- a/services/agentsniffer/agentsniffer.go
+++ b/services/agentsniffer/agentsniffer.go
@@ -47,7 +47,7 @@ func scan(wg *sync.WaitGroup, ip string, s state.IState) {
 
 	devType := string(buff[:n])
 
-	_, err = s.AgentByID(ip)
+	_, err = s.AgentByIP(ip)
 	if err != nil {
 		resp, err := http.Get("http://" + ip + "/config")
 		defer resp.Body.Close()


### PR DESCRIPTION
**Business justification:** https://trello.com/c/Jg5gY5gk/188-home-fix-agent-dups-while-sniffing

**Description:** When sniffing multiple times agents were duplicated. The cause of this was, `IP` was compared against `HardwareID` when smarthome found new agent. This PR makes sure `IP` is still compared against existing `IP`.
