### PR TITLE
HOME-197 - On 'no agents available' is rendered' flashes

### DIFF
--- a/client/models/agents/reducers.js
+++ b/client/models/agents/reducers.js
@@ -3,7 +3,7 @@ import * as actionTypes from './actionTypes';
 import * as types from './types';
 
 const defaultState: types.State = {
-  isLoading: false,
+  isLoading: true,
   error: '',
   agents: [],
 };


### PR DESCRIPTION
**Business justification:** https://trello.com/c/PSTwBadQ/197-home-197-on-no-agents-available-is-rendered-flashes

**Description:** Changing loader default state so the user can see the platform is loading agents instead of showing false info.
