### PR TITLE
HOME-199 - Default make command shouldn't generate version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ install:
 
 .PHONY: all
 all:
-	$(GOCMD) generate
 	$(GOCMD) build -mod=vendor -o smarthome
 	$(NPM) rebuild node-sass
 	$(NPM) run build:$(mode)


### PR DESCRIPTION
**Business justification:** https://trello.com/c/vWBDFrwY/199-home-default-make-command-shouldnt-generate-version

**Description:** Default make command shouldn't generate version.

