### PR TITLE
HOME-202 - Non existing agentConfig causing error on agents list

### DIFF
--- a/client/models/agentConfigs/queries.js
+++ b/client/models/agentConfigs/queries.js
@@ -7,5 +7,5 @@ import * as types from './types';
 export const getAgentConfigByAgentId = (
   agentConfigs: $ReadOnlyArray<types.AgentConfig>,
   agentID: agentTypes.AgentID
-): types.AgentConfig => _.find(agentConfigs, { agentId: agentID });
+): types.AgentConfig => _.find(agentConfigs, { agentId: agentID }) || {};
 /* eslint-enable import/prefer-default-export */

--- a/client/models/agentConfigs/queries.test.js
+++ b/client/models/agentConfigs/queries.test.js
@@ -21,5 +21,10 @@ describe('models/agentConfigs/queries', () => {
       const result = queries.getAgentConfigByAgentId(agentConfigs, '90346453');
       expect(result).toEqual(agentConfigs[1]);
     });
+
+    it('should return empty object when no agentConfig found', () => {
+      const result = queries.getAgentConfigByAgentId(agentConfigs, '84750192');
+      expect(result).toEqual({});
+    });
   });
 });


### PR DESCRIPTION
**Business justification:** https://trello.com/c/h1bOGEp6/202-home-non-existing-agentconfig-causing-error-on-agents-list

**Description:** `AgentConfig` is obligatory for most components and as such should be served. When `AgentConfig` doesn't exist is should be substituted with `{}` so when reaching for it's properties it won't cause 
> Property of undefined

error.
