### PR TITLE
HOME-203 - Non existing AgentConfigs causing erros while editing agents

### DIFF
--- a/client/models/agentConfigs/reducers.js
+++ b/client/models/agentConfigs/reducers.js
@@ -12,19 +12,24 @@ const defaultState = {
 function updateProperty(state: types.State, action: Object) {
   const { key, value, agentID } = action;
   const { agentConfigs } = state;
+  let newAgentConfigs = [];
 
   const agentConfig =
     queries.getAgentConfigByAgentId(agentConfigs, agentID) || {};
-  agentConfig[key] = value;
 
-  const newAgentConfig = _.defaults(agentConfigs, {
-    [action.key]: action.value,
-  });
-
-  agentConfigs[agentID] = newAgentConfig;
+  if (_.isEmpty(agentConfig)) {
+    const newAgentConfig = {
+      agentId: agentID,
+      [action.key]: action.value,
+    }
+    newAgentConfigs = _.concat(agentConfigs, [newAgentConfig]);
+  } else {
+    agentConfig[key] = value;
+    newAgentConfigs = _.concat(_.filter(agentConfigs, c => c.agentId != agentID), [agentConfig]);
+  }
 
   return Object.assign({}, state, {
-    agentConfigs,
+    agentConfigs: newAgentConfigs,
   });
 }
 

--- a/client/models/agentConfigs/reducers.js
+++ b/client/models/agentConfigs/reducers.js
@@ -21,11 +21,14 @@ function updateProperty(state: types.State, action: Object) {
     const newAgentConfig = {
       agentId: agentID,
       [action.key]: action.value,
-    }
+    };
     newAgentConfigs = _.concat(agentConfigs, [newAgentConfig]);
   } else {
     agentConfig[key] = value;
-    newAgentConfigs = _.concat(_.filter(agentConfigs, c => c.agentId != agentID), [agentConfig]);
+    newAgentConfigs = _.concat(
+      _.filter(agentConfigs, c => c.agentId !== agentID),
+      [agentConfig]
+    );
   }
 
   return Object.assign({}, state, {

--- a/client/models/agentConfigs/reducers.test.js
+++ b/client/models/agentConfigs/reducers.test.js
@@ -1,0 +1,55 @@
+import _ from 'lodash';
+import reducers from './reducers';
+import * as actions from './actions';
+
+const agentConfigs = [
+  {
+    id: '5d2af74d7b43643c977d23c2',
+    agentId: '43366411',
+    name: 'Badroom',
+    temperature: 0,
+  },
+  {
+    id: '4l2af74d7b43643c977d23e1',
+    agentId: '90346453',
+    name: 'Livingroom',
+    temperature: 0,
+  },
+];
+
+const state = {
+  agentConfigs,
+};
+
+describe('models/agentConfigs/reducers', () => {
+  describe('UPDATE_PROPERTY', () => {
+    it('should add new AgentConfig to state', () => {
+      const action = actions.updateProperty('12345678', 'name', 'New Agent');
+      const expectedAgentConfigs = _.concat(agentConfigs, [{
+        agentId: '12345678',
+        name: 'New Agent',
+      }]);
+      const expectedState = {
+        agentConfigs: expectedAgentConfigs,
+      };
+
+      const result = reducers(state, action);
+      expect(result).toEqual(expectedState);
+    });
+
+    it('should update existing AgentConfig', () => {
+      const action = actions.updateProperty('90346453', 'name', 'New Agent');
+      const expectedAgentConfigs = [agentConfigs[0], {
+        id: '4l2af74d7b43643c977d23e1',
+        agentId: '90346453',
+        name: 'New Agent',
+        temperature: 0,
+      }];
+      const expectedState = {
+        agentConfigs: expectedAgentConfigs,
+      };
+      const result = reducers(state, action);
+      expect(result).toEqual(expectedState);
+    });
+  });
+});

--- a/client/models/agentConfigs/reducers.test.js
+++ b/client/models/agentConfigs/reducers.test.js
@@ -25,10 +25,12 @@ describe('models/agentConfigs/reducers', () => {
   describe('UPDATE_PROPERTY', () => {
     it('should add new AgentConfig to state', () => {
       const action = actions.updateProperty('12345678', 'name', 'New Agent');
-      const expectedAgentConfigs = _.concat(agentConfigs, [{
-        agentId: '12345678',
-        name: 'New Agent',
-      }]);
+      const expectedAgentConfigs = _.concat(agentConfigs, [
+        {
+          agentId: '12345678',
+          name: 'New Agent',
+        },
+      ]);
       const expectedState = {
         agentConfigs: expectedAgentConfigs,
       };
@@ -39,12 +41,15 @@ describe('models/agentConfigs/reducers', () => {
 
     it('should update existing AgentConfig', () => {
       const action = actions.updateProperty('90346453', 'name', 'New Agent');
-      const expectedAgentConfigs = [agentConfigs[0], {
-        id: '4l2af74d7b43643c977d23e1',
-        agentId: '90346453',
-        name: 'New Agent',
-        temperature: 0,
-      }];
+      const expectedAgentConfigs = [
+        agentConfigs[0],
+        {
+          id: '4l2af74d7b43643c977d23e1',
+          agentId: '90346453',
+          name: 'New Agent',
+          temperature: 0,
+        },
+      ];
       const expectedState = {
         agentConfigs: expectedAgentConfigs,
       };

--- a/client/models/agentConfigs/sagas.js
+++ b/client/models/agentConfigs/sagas.js
@@ -32,7 +32,7 @@ export function* onFetchAgentConfigs({
   const data = yield call(callFetchAgentConfigs, agentID);
 
   if (data !== undefined) {
-    const agentConfigs = data._embedded.configs;
+    const agentConfigs = data._embedded.configs || [];
     yield put(actions.loadAgentConfigs(agentConfigs));
   } else {
     yield put(


### PR DESCRIPTION
**Business justification:** https://trello.com/c/6WZfei55/203-home-non-existing-agentconfigs-causing-erros-while-editing-agents

**Description:** When user was accessing agent edit page and no agent cofigs were loaded it was causing runtime error. This PR fixes the mechanics.
