### PR TITLE
HOME-253 - Password on API end should not be hashed

### DIFF
--- a/processes/webserver/controllers/register.go
+++ b/processes/webserver/controllers/register.go
@@ -34,7 +34,7 @@ func Register(w http.ResponseWriter, r *http.Request, opt router.UrlOptions, sm 
 		newUser = &user.User{
 			ID:       bson.NewObjectId(),
 			Username: username,
-			Password: utils.HashString(password),
+			Password: password,
 			APIKey:   utils.HashString(username + password),
 		}
 


### PR DESCRIPTION
**Business justification:** https://trello.com/c/4MElgX6U/253-home-password-on-api-end-should-not-be-hashed

**Description:** User password is already hashed on the SH-PANEL side, it shouldn't be re-hashed on the API side.

